### PR TITLE
Update development environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
-  "image": "mcr.microsoft.com/devcontainers/python:dev-3.13-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/python:3.14",
   "name": "SkyBellGen integration development",
 
   "appPort": ["9123:8123"],
@@ -10,7 +10,6 @@
         "ms-python.python",
         "ms-python.pylint",
         "ms-python.vscode-pylance",
-        "visualstudioexptteam.vscodeintellicode",
         "redhat.vscode-yaml",
         "ryanluker.vscode-coverage-gutters",
         "esbenp.prettier-vscode",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "python.linting.pylintEnabled": true,
   "python.linting.enabled": true,
   "python.formatting.provider": "black",
   "isort.args": [
@@ -18,7 +17,7 @@
     "--known-first-party=custom_components.skybellgen,tests",
     "--combine-as-imports"
   ],
-  "python.pythonPath": "venv/bin/python",
+  "python.pythonPath": "usr/local/bin/python",
   "files.associations": {
     "*.yaml": "home-assistant"
   },

--- a/custom_components/skybellgen/__init__.py
+++ b/custom_components/skybellgen/__init__.py
@@ -32,7 +32,7 @@ PLATFORMS = [
 # Calls to the communications driver should be serialized
 PARALLEL_UPDATES = 1
 
-CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)  # pylint: disable=C0103
 
 
 @dataclass

--- a/custom_components/skybellgen/camera.py
+++ b/custom_components/skybellgen/camera.py
@@ -287,6 +287,7 @@ class SkybellLiveStreamCamera(SkybellCamera):
         if expiration_ts < datetime.now(tz=timezone.utc):
             _LOGGER.info(
                 "Livestream endpoint expired. Restarting livestream for %s",
+                self.entity_id,
             )
             await self._async_stop_livestream()
             await self._async_start_livestream()

--- a/custom_components/skybellgen/manifest.json
+++ b/custom_components/skybellgen/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/tcareyintx/skybellgen/issues",
   "loggers": ["skybellgen"],
   "requirements": ["aioskybellgen==0.1.5", "boto3>=1.39.9"],
-  "version": "0.3.4"
+  "version": "0.3.5"
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -50,6 +50,9 @@ async def test_setup_and_unload_entry(
 
     # Execute the Unload the entry
     assert await async_unload_entry(hass, config_entry)
+    # Clean up the DataCoordinators and HubCoordinator after unloading the entry
+    await hc.async_shutdown()
+    await dc[0].async_shutdown()
 
 
 async def test_setup_entry_exception(hass, error_initialize):


### PR DESCRIPTION
Update development environment to remain compatible with pytest-homeassistant-custom-component
Updates for latest pylint errors
Update devcontainter to use python3.14 for compatibility to homeassistant